### PR TITLE
chore: add local pre-commit gitleaks hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Block commits that introduce secrets. Mirrors the CI gitleaks job locally.
+set -euo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "pre-commit: gitleaks not installed — skipping secret scan" >&2
+  echo "  brew install gitleaks  # or see https://github.com/gitleaks/gitleaks" >&2
+  exit 0
+fi
+
+gitleaks protect --staged --redact --no-banner

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ bash install.sh
 
 Idempotent. Re-run after `git pull` to refresh symlinks.
 
+## Dev setup (contributors only)
+
+After cloning, wire the local pre-commit hook so secrets get caught before they ever reach a commit:
+
+```bash
+git config core.hooksPath .githooks
+brew install gitleaks   # or see https://github.com/gitleaks/gitleaks
+```
+
+The same scan runs in CI (`.github/workflows/secret-scan.yml`) and is a required status check on `main` — the local hook just gives faster feedback.
+
 ## Layout
 
 | Path | What lives here |


### PR DESCRIPTION
## Summary
- Adds `.githooks/pre-commit` running `gitleaks protect --staged` so secrets get caught at `git commit` time, before CI.
- Documents the one-time `git config core.hooksPath .githooks` opt-in in README.

Mirrors the existing `secret-scan` workflow that runs in CI, just shifted left for faster feedback.

## Test plan
- [x] Hook exits 0 on clean staged diff
- [x] Hook exits 1 + reports leak when a fake AWS key is staged
- [x] `secret-scan` CI passes on this branch
- [ ] PR can be merged via squash/rebase only (linear-history rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)