### PR TITLE
chore: normalize em-dashes to hyphens

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if ! command -v gitleaks >/dev/null 2>&1; then
-  echo "pre-commit: gitleaks not installed — skipping secret scan" >&2
+  echo "pre-commit: gitleaks not installed - skipping secret scan" >&2
   echo "  brew install gitleaks  # or see https://github.com/gitleaks/gitleaks" >&2
   exit 0
 fi

--- a/MIGRATED.md
+++ b/MIGRATED.md
@@ -17,7 +17,7 @@ Migrated GitHub issues:
 - dotfiles#79 (META) → top-level tracker
 
 Issues that stayed in dotfiles (operational, dotfiles-specific):
-- #66, #67 + #36–46 — sketchybar polish
-- #70, #71, #72 — PowerShell improvements
-- #80 — chezmoi evaluation
-- #25, #24, #32 — misc dotfiles
+- #66, #67 + #36–46 - sketchybar polish
+- #70, #71, #72 - PowerShell improvements
+- #80 - chezmoi evaluation
+- #25, #24, #32 - misc dotfiles

--- a/README.md
+++ b/README.md
@@ -22,24 +22,24 @@ git config core.hooksPath .githooks
 brew install gitleaks   # or see https://github.com/gitleaks/gitleaks
 ```
 
-The same scan runs in CI (`.github/workflows/secret-scan.yml`) and is a required status check on `main` — the local hook just gives faster feedback.
+The same scan runs in CI (`.github/workflows/secret-scan.yml`) and is a required status check on `main` - the local hook just gives faster feedback.
 
 ## Layout
 
 | Path | What lives here |
 |------|-----------------|
 | `plugin-routing.md` | Canonical token-aware tool/skill routing reference. Auto-loaded by the global CLAUDE.md via `@~/.claude/plugin-routing.md`. |
-| `skills/picking-model-tier/` | Skill — checks task vs current model tier at start-of-work. |
-| `skills/writing-handoffs/` | Skill — appends `## Recommended Model` section to handoff docs. |
-| `hooks/precompact-context.sh` | PreCompact hook — injects MEMORY.md + CLAUDE.md into compaction context. |
+| `skills/picking-model-tier/` | Skill - checks task vs current model tier at start-of-work. |
+| `skills/writing-handoffs/` | Skill - appends `## Recommended Model` section to handoff docs. |
+| `hooks/precompact-context.sh` | PreCompact hook - injects MEMORY.md + CLAUDE.md into compaction context. |
 | `docs/workflow.md` | Human-readable one-page playbook (companion to `plugin-routing.md` which is for Claude). |
 | `docs/superpowers/specs/` | Design docs for workflow improvements (model-switching policy, forcing functions, etc.). |
 | `docs/superpowers/plans/` | Implementation plans derived from specs. |
 
 ## What this repo does NOT contain
 
-- `~/.claude/settings.json` — has machine-specific paths; per-machine state
-- `~/.claude/projects/*/memory/` — per-project memory snapshots
+- `~/.claude/settings.json` - has machine-specific paths; per-machine state
+- `~/.claude/projects/*/memory/` - per-project memory snapshots
 - Project-specific skills (those live in the project's repo)
 
 ## Origin

--- a/docs/superpowers/plans/2026-04-27-cc-config-bootstrap.md
+++ b/docs/superpowers/plans/2026-04-27-cc-config-bootstrap.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Fresh-start migration (no `git filter-repo` history transplant). Files copied into cc-config; `install.sh` symlinks them into `~/.claude/`; dotfiles deletes its copies after verification proves cc-config installs are working. Workflow design issues (#75-79) recreated in cc-config; operational dotfiles issues stay in dotfiles.
 
-**Tech Stack:** bash, git, gh CLI. No tests in the unit-test sense — verification is operational (`readlink`, fresh-session checks, `gh issue list`).
+**Tech Stack:** bash, git, gh CLI. No tests in the unit-test sense - verification is operational (`readlink`, fresh-session checks, `gh issue list`).
 
 **Pre-requisites already complete:**
 - ✅ cc-config repo created on GitHub (private) and cloned to `~/cc-config`
@@ -176,9 +176,9 @@ The replacement "See also" section should be:
 ```markdown
 ## See also
 
-- [`plugin-routing.md`](../plugin-routing.md) — technical routing reference (for Claude)
-- [Spec: model-switching policy](superpowers/specs/2026-04-27-model-switching-policy-design.md) — once written
-- [META issue](https://github.com/jem0ntr053/cc-config/issues/) — current workflow improvement work
+- [`plugin-routing.md`](../plugin-routing.md) - technical routing reference (for Claude)
+- [Spec: model-switching policy](superpowers/specs/2026-04-27-model-switching-policy-design.md) - once written
+- [META issue](https://github.com/jem0ntr053/cc-config/issues/) - current workflow improvement work
 ```
 
 Use the Write tool (or `tee`) to create the final file with this section replaced. Everything else (overview, sections, tables) stays identical.
@@ -205,7 +205,7 @@ git push
 
 ### Task 3: Run cc-config install.sh and verify all symlinks point to cc-config
 
-**Goal:** Activate cc-config — run its installer, then prove the four expected symlinks resolve into cc-config and not dotfiles.
+**Goal:** Activate cc-config - run its installer, then prove the four expected symlinks resolve into cc-config and not dotfiles.
 
 **Files:**
 - Modify (via symlink): `~/.claude/plugin-routing.md`, `~/.claude/skills/picking-model-tier`, `~/.claude/skills/writing-handoffs`, `~/.claude/hooks/precompact-context.sh`
@@ -224,7 +224,7 @@ readlink ~/.claude/hooks/precompact-context.sh # expect: /Users/montrose/cc-conf
 
 **Steps:**
 
-- [ ] **Step 1: Pre-flight — record current symlink state**
+- [ ] **Step 1: Pre-flight - record current symlink state**
 
 ```bash
 echo "=== before install ==="
@@ -267,7 +267,7 @@ echo "ctx-len: $(jq -r '.hookSpecificOutput.additionalContext | length' /tmp/pre
 ```
 Expected: exit 0, "PreCompact", non-zero ctx-len.
 
-If anything fails: the original `~/.claude/hooks/precompact-context.sh` content is preserved in `~/cc-config/hooks/precompact-context.sh` — restore via `cp ~/cc-config/hooks/precompact-context.sh ~/.claude/hooks/precompact-context.sh` (without symlink).
+If anything fails: the original `~/.claude/hooks/precompact-context.sh` content is preserved in `~/cc-config/hooks/precompact-context.sh` - restore via `cp ~/cc-config/hooks/precompact-context.sh ~/.claude/hooks/precompact-context.sh` (without symlink).
 
 ---
 
@@ -294,7 +294,7 @@ cd /tmp && claude
 
 **Steps:**
 
-- [ ] **Step 1: Open a fresh `claude` session in a different terminal or `/clear` this one** (this turn-out boundary is a manual user action — agent dispatching plan should ask the user to confirm)
+- [ ] **Step 1: Open a fresh `claude` session in a different terminal or `/clear` this one** (this turn-out boundary is a manual user action - agent dispatching plan should ask the user to confirm)
 
 - [ ] **Step 2: Verify the system-reminder available-skills list includes both** (look for lines like `- picking-model-tier: ...` and `- writing-handoffs: ...`)
 
@@ -302,7 +302,7 @@ cd /tmp && claude
 
 - [ ] **Step 4: Repeat for `writing-handoffs`**
 
-If either fails: do NOT proceed to Task 5 (which deletes from dotfiles). Investigate first — likely cause is wrong symlink target or Claude Code cache.
+If either fails: do NOT proceed to Task 5 (which deletes from dotfiles). Investigate first - likely cause is wrong symlink target or Claude Code cache.
 
 ---
 
@@ -314,7 +314,7 @@ If either fails: do NOT proceed to Task 5 (which deletes from dotfiles). Investi
 - Delete from dotfiles: `common/.claude/plugin-routing.md`
 - Delete from dotfiles: `common/.claude/skills/picking-model-tier/` (and parent if empty)
 - Delete from dotfiles: `common/.claude/skills/writing-handoffs/` (and parent if empty)
-- Modify: `~/dotfiles/docs/file-map.md` — remove the three rows for the deleted files
+- Modify: `~/dotfiles/docs/file-map.md` - remove the three rows for the deleted files
 
 **Acceptance Criteria:**
 - [ ] Files removed from dotfiles main (after PR merge)
@@ -381,7 +381,7 @@ jem0ntr053/cc-config and are symlinked into ~/.claude/ via that
 repo's install.sh. Dotfiles-specific skills (dotfiles-*) stay here.
 
 The @~/.claude/plugin-routing.md import in this repo's CLAUDE.md
-continues to resolve correctly — only the symlink target changed.
+continues to resolve correctly - only the symlink target changed.
 
 Co-extraction: closes follow-up to PRs #69 and #73; superseded
 PR #74 (workflow.md moved to cc-config).
@@ -395,9 +395,9 @@ git push -u origin cleanup/post-cc-config-extraction
 ```bash
 gh pr create --title "chore: extract cross-project Claude config to cc-config repo" --body "$(cat <<'EOF'
 ## Summary
-Extracts the cross-project Claude Code config (plugin-routing.md, picking-model-tier skill, writing-handoffs skill) from dotfiles into the new private \`jem0ntr053/cc-config\` repo. These were already cross-project in spirit (stowed into \`~/.claude/\`) — now they live with the rest of the cross-project workflow improvement work.
+Extracts the cross-project Claude Code config (plugin-routing.md, picking-model-tier skill, writing-handoffs skill) from dotfiles into the new private \`jem0ntr053/cc-config\` repo. These were already cross-project in spirit (stowed into \`~/.claude/\`) - now they live with the rest of the cross-project workflow improvement work.
 
-After merge, dotfiles stops loading workflow design context every session — savings repeat per-session.
+After merge, dotfiles stops loading workflow design context every session - savings repeat per-session.
 
 ## Verification (already done before opening this PR)
 - cc-config repo bootstrapped, install.sh symlinks all four targets correctly
@@ -406,7 +406,7 @@ After merge, dotfiles stops loading workflow design context every session — sa
 
 ## Out of scope
 - Workflow design issues #75-79 migrate to cc-config in a separate gh-only step (no PR needed)
-- PR #74 (workflow.md draft) closed without merge — content moved to cc-config
+- PR #74 (workflow.md draft) closed without merge - content moved to cc-config
 EOF
 )"
 
@@ -426,7 +426,7 @@ cd ~/dotfiles && git checkout main && git pull
 
 ### Task 6: Verify symlinks still resolve and skills still load post-dotfiles-cleanup
 
-**Goal:** Sanity check after the dotfiles deletion — symlinks must still point into cc-config (they should, untouched by dotfiles changes) and skills must still load.
+**Goal:** Sanity check after the dotfiles deletion - symlinks must still point into cc-config (they should, untouched by dotfiles changes) and skills must still load.
 
 **Files:** None modified.
 
@@ -460,7 +460,7 @@ Expected: 10 lines all starting with "OK".
 
 - [ ] **Step 1: Run readlink verification block** (above)
 
-- [ ] **Step 2: Manual — fresh `claude` session, confirm both cc-config-served skills still listed**
+- [ ] **Step 2: Manual - fresh `claude` session, confirm both cc-config-served skills still listed**
 
 If anything is "BAD": investigate immediately. cc-config symlinks should not have changed. dotfiles symlinks for `dotfiles-*` skills are unaffected by this migration.
 
@@ -470,7 +470,7 @@ If anything is "BAD": investigate immediately. cc-config symlinks should not hav
 
 **Goal:** Close the unmerged dotfiles PR that drafted `docs/workflow.md`, since that file now lives in cc-config.
 
-**Files:** None modified locally — GitHub-only operation.
+**Files:** None modified locally - GitHub-only operation.
 
 **Acceptance Criteria:**
 - [ ] Dotfiles PR #74 is closed (not merged)
@@ -490,7 +490,7 @@ Expected: `CLOSED`.
 gh pr close 74 --repo jem0ntr053/dotfiles --comment "$(cat <<'EOF'
 Superseded by the cc-config bootstrap migration (2026-04-27). \`docs/workflow.md\` now lives at https://github.com/jem0ntr053/cc-config/blob/main/docs/workflow.md.
 
-The dotfiles repo no longer carries cross-project workflow docs — see the cleanup PR that removes plugin-routing.md and the generic skills.
+The dotfiles repo no longer carries cross-project workflow docs - see the cleanup PR that removes plugin-routing.md and the generic skills.
 EOF
 )" --delete-branch
 ```
@@ -509,7 +509,7 @@ Expected: `CLOSED`, branch removed locally too.
 
 **Goal:** Recreate the workflow design issues (sub-issues A/B/C/D and the META) in cc-config. Cross-link old and new. Pin the new META in cc-config.
 
-**Files:** None local — GitHub-only.
+**Files:** None local - GitHub-only.
 
 **Acceptance Criteria:**
 - [ ] Five new issues exist in cc-config (one per migrated dotfiles issue)
@@ -563,7 +563,7 @@ dotfiles#77 -> cc-config#__
 dotfiles#78 -> cc-config#__
 ```
 
-Also note: the comment on dotfiles#75 carries the "checkpoint" of the model-switching brainstorm. Re-post that comment on the new cc-config issue too — it's load-bearing for resuming A:
+Also note: the comment on dotfiles#75 carries the "checkpoint" of the model-switching brainstorm. Re-post that comment on the new cc-config issue too - it's load-bearing for resuming A:
 
 ```bash
 # Get the checkpoint comment body from dotfiles#75 (the comment we added earlier)
@@ -623,15 +623,15 @@ Expected: five new cc-config issues; five dotfiles closures; one pinned cc-confi
 ## Self-review notes
 
 **Spec coverage:**
-- ✅ Bootstrap empty repo — already done (pre-requisite)
-- ✅ Copy files (skills, plugin-routing.md, hook, workflow.md) — Tasks 0, 1, 2
-- ✅ Run install.sh + verify symlinks — Task 3
-- ✅ Verify Claude Code finds skills — Task 4
-- ✅ Branch in dotfiles, remove migrated content + update file-map.md — Task 5
-- ✅ Verify post-cleanup — Task 6
-- ✅ Close PR #74 — Task 7
-- ✅ Issue migration — Task 8
-- ✅ Resume A's spec write — explicitly out of scope (success criterion of bootstrap is "cc-config functional + issues migrated"; A is follow-up)
+- ✅ Bootstrap empty repo - already done (pre-requisite)
+- ✅ Copy files (skills, plugin-routing.md, hook, workflow.md) - Tasks 0, 1, 2
+- ✅ Run install.sh + verify symlinks - Task 3
+- ✅ Verify Claude Code finds skills - Task 4
+- ✅ Branch in dotfiles, remove migrated content + update file-map.md - Task 5
+- ✅ Verify post-cleanup - Task 6
+- ✅ Close PR #74 - Task 7
+- ✅ Issue migration - Task 8
+- ✅ Resume A's spec write - explicitly out of scope (success criterion of bootstrap is "cc-config functional + issues migrated"; A is follow-up)
 
 **Type/path consistency:**
 - All paths use `~/cc-config/` and `~/dotfiles/` consistently
@@ -642,4 +642,4 @@ Expected: five new cc-config issues; five dotfiles closures; one pinned cc-confi
 - Task 4 explicit "do NOT proceed to Task 5 if verification fails"
 - Task 6 catches any regression caused by Task 5
 
-**Open assumption:** Step 3 of Task 2 (workflow.md link adaptation) is somewhat manual — the agent executing should use Read + Edit tools rather than scripted sed, since the link structure is best done with eyes on the content. Documented inline in the task.
+**Open assumption:** Step 3 of Task 2 (workflow.md link adaptation) is somewhat manual - the agent executing should use Read + Edit tools rather than scripted sed, since the link structure is best done with eyes on the content. Documented inline in the task.

--- a/docs/superpowers/plans/2026-04-27-cc-config-bootstrap.md.tasks.json
+++ b/docs/superpowers/plans/2026-04-27-cc-config-bootstrap.md.tasks.json
@@ -31,7 +31,7 @@
       "subject": "Task 4: Verify Claude Code finds picking-model-tier + writing-handoffs via cc-config symlinks",
       "status": "pending",
       "blockedBy": [3],
-      "description": "**Goal:** Manual confirmation that fresh Claude session discovers both skills.\n\n**Critical:** If verification fails, do NOT proceed to Task 5 (dotfiles deletion).\n\n```json:metadata\n{\"files\":[],\"verifyCommand\":\"# Manual — open fresh claude session and check available skills\",\"acceptanceCriteria\":[\"picking-model-tier listed in fresh session\",\"writing-handoffs listed\",\"both invoke successfully\"]}\n```"
+      "description": "**Goal:** Manual confirmation that fresh Claude session discovers both skills.\n\n**Critical:** If verification fails, do NOT proceed to Task 5 (dotfiles deletion).\n\n```json:metadata\n{\"files\":[],\"verifyCommand\":\"# Manual - open fresh claude session and check available skills\",\"acceptanceCriteria\":[\"picking-model-tier listed in fresh session\",\"writing-handoffs listed\",\"both invoke successfully\"]}\n```"
     },
     {
       "id": 5,

--- a/docs/superpowers/specs/2026-04-27-cc-config-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-04-27-cc-config-bootstrap-design.md
@@ -1,4 +1,4 @@
-# cc-config bootstrap — design
+# cc-config bootstrap - design
 
 **Date:** 2026-04-27
 **Topic:** Extract cross-project Claude Code workflow config from `jem0ntr053/dotfiles` into a new private repo (`jem0ntr053/cc-config`) and migrate the workflow improvement design issues with it.
@@ -20,11 +20,11 @@ Establish a clean home for cross-project Claude Code workflow config (skills, ho
 
 | # | Question | Decision |
 |---|----------|----------|
-| 1 | Scope | **Option 2** — all cross-project Claude config (generic skills, plugin-routing.md, hooks, workflow design docs). Project-specific skills (`dotfiles-*`) stay in dotfiles. |
-| 2 | Install mechanism | **Option B** — plain `ln -sf` script. No Stow / chezmoi for this repo (small enough to not warrant a tool). Stow remains in dotfiles. |
+| 1 | Scope | **Option 2** - all cross-project Claude config (generic skills, plugin-routing.md, hooks, workflow design docs). Project-specific skills (`dotfiles-*`) stay in dotfiles. |
+| 2 | Install mechanism | **Option B** - plain `ln -sf` script. No Stow / chezmoi for this repo (small enough to not warrant a tool). Stow remains in dotfiles. |
 | 3 | Hosting + name | Private GitHub repo, named `cc-config`. |
-| 4 | Issue location | **Choice X** — workflow design issues (dotfiles#75/76/77/78/79) move to cc-config. Operational issues (#70/71/72 PowerShell, #80 chezmoi, sketchybar polish, etc.) stay in dotfiles. |
-| 5 | Code migration approach | **Option F** — fresh start. No `git filter-repo` history preservation. `MIGRATED.md` records origin. |
+| 4 | Issue location | **Choice X** - workflow design issues (dotfiles#75/76/77/78/79) move to cc-config. Operational issues (#70/71/72 PowerShell, #80 chezmoi, sketchybar polish, etc.) stay in dotfiles. |
+| 5 | Code migration approach | **Option F** - fresh start. No `git filter-repo` history preservation. `MIGRATED.md` records origin. |
 
 Rationales for each are in the brainstorm transcript on dotfiles#75 (saved as a comment).
 
@@ -45,7 +45,7 @@ cc-config/
 │   └── writing-handoffs/SKILL.md
 ├── hooks/
 │   ├── precompact-context.sh             # adopted from previously-untracked ~/.claude/hooks/
-│   └── (require-branch-on-edit.sh — added later via cc-config issue C)
+│   └── (require-branch-on-edit.sh - added later via cc-config issue C)
 └── docs/
     ├── workflow.md                       # human-readable playbook
     └── superpowers/
@@ -73,29 +73,29 @@ Re-running the script after `git pull` is safe and refreshes targets.
 
 ### What this repo deliberately omits
 
-- `~/.claude/settings.json` — contains machine-specific paths and per-machine permission state
-- `~/.claude/projects/<sanitized-cwd>/memory/` — per-project session-recall hints, not portable
-- Project-specific skills (`dotfiles-*` etc.) — those live with their project's source
+- `~/.claude/settings.json` - contains machine-specific paths and per-machine permission state
+- `~/.claude/projects/<sanitized-cwd>/memory/` - per-project session-recall hints, not portable
+- Project-specific skills (`dotfiles-*` etc.) - those live with their project's source
 
 ---
 
-## Migration plan (high-level — detailed implementation plan in `docs/superpowers/plans/`)
+## Migration plan (high-level - detailed implementation plan in `docs/superpowers/plans/`)
 
-1. ✅ **Bootstrap empty repo** — create on GitHub, init locally, scaffold dirs, write README/MIGRATED/install.sh, first commit
+1. ✅ **Bootstrap empty repo** - create on GitHub, init locally, scaffold dirs, write README/MIGRATED/install.sh, first commit
 2. **Copy files into cc-config:**
    - `dotfiles/common/.claude/plugin-routing.md` → `cc-config/plugin-routing.md`
    - `dotfiles/common/.claude/skills/picking-model-tier/` → `cc-config/skills/picking-model-tier/`
    - `dotfiles/common/.claude/skills/writing-handoffs/` → `cc-config/skills/writing-handoffs/`
    - `~/.claude/hooks/precompact-context.sh` → `cc-config/hooks/precompact-context.sh`
    - `dotfiles` PR #74 branch's `docs/workflow.md` → `cc-config/docs/workflow.md`
-3. **Run install.sh** — verify all four symlinks resolve via `readlink`
-4. **Verify Claude Code still finds skills** — start fresh `claude` session, confirm `picking-model-tier` and `writing-handoffs` are listed in available skills
+3. **Run install.sh** - verify all four symlinks resolve via `readlink`
+4. **Verify Claude Code still finds skills** - start fresh `claude` session, confirm `picking-model-tier` and `writing-handoffs` are listed in available skills
 5. **Branch in dotfiles, remove migrated content:**
    - Delete `common/.claude/plugin-routing.md`, `common/.claude/skills/picking-model-tier/`, `common/.claude/skills/writing-handoffs/`
    - Update CLAUDE.md (remove file-map rows, update skill references if any)
    - Update `docs/file-map.md` similarly
    - PR + merge in dotfiles
-6. **Verify skills still resolve after dotfiles cleanup** — symlinks now point to cc-config; confirm `readlink ~/.claude/skills/picking-model-tier` shows cc-config path
+6. **Verify skills still resolve after dotfiles cleanup** - symlinks now point to cc-config; confirm `readlink ~/.claude/skills/picking-model-tier` shows cc-config path
 7. **Close PR #74** in dotfiles (workflow.md superseded by cc-config copy)
 8. **Issue migration (Choice X):**
    - For each of dotfiles#75/76/77/78/79: `gh issue view <#> --json title,body --jq` → recreate via `gh issue create --repo jem0ntr053/cc-config`
@@ -112,7 +112,7 @@ Re-running the script after `git pull` is safe and refreshes targets.
 | New install.sh broken → Claude Code can't find skills | Verify before deleting from dotfiles. Existing dotfiles symlinks remain intact until step 5. |
 | Symlink conflicts on existing `~/.claude/skills/...` targets | `-sfn` flag overwrites. Pre-flight: `readlink ~/.claude/skills/picking-model-tier` to confirm starting state. |
 | `~/.claude/hooks/precompact-context.sh` is currently a real file (not symlink) | Install.sh `-f` flag deletes the real file before symlinking. Verified with current contents already preserved in cc-config repo. |
-| `@~/.claude/plugin-routing.md` reference in user's global CLAUDE.md breaks | Path stays valid — symlink continues to resolve, just points to cc-config now |
+| `@~/.claude/plugin-routing.md` reference in user's global CLAUDE.md breaks | Path stays valid - symlink continues to resolve, just points to cc-config now |
 | Open PR #74 conflicts with dotfiles cleanup | Close #74 in step 7 before opening dotfiles cleanup PR |
 | Issues lose linkage during migration | Cross-link via comments on both old and new issues; META in cc-config explicitly mentions origin |
 
@@ -120,10 +120,10 @@ Re-running the script after `git pull` is safe and refreshes targets.
 
 ## Out of scope (explicitly deferred)
 
-- Migrating dotfiles install from Stow to chezmoi — tracked as dotfiles#80, deferred until workflow initiative stable
-- Adopting `~/.claude/settings.json` into version control — has machine-specific paths, separate evaluation
-- Adopting `~/.claude/projects/*/memory/` into version control — per-project, evaluate later
-- Building the actual workflow improvements (model-switching rule, forcing functions, etc.) — separate specs that land in this repo after bootstrap
+- Migrating dotfiles install from Stow to chezmoi - tracked as dotfiles#80, deferred until workflow initiative stable
+- Adopting `~/.claude/settings.json` into version control - has machine-specific paths, separate evaluation
+- Adopting `~/.claude/projects/*/memory/` into version control - per-project, evaluate later
+- Building the actual workflow improvements (model-switching rule, forcing functions, etc.) - separate specs that land in this repo after bootstrap
 
 ## Dependencies
 

--- a/docs/superpowers/specs/2026-04-27-model-switching-policy-design.md
+++ b/docs/superpowers/specs/2026-04-27-model-switching-policy-design.md
@@ -1,4 +1,4 @@
-# Model-switching policy — design
+# Model-switching policy - design
 
 **Date:** 2026-04-27
 **Topic:** Define when to switch Claude model tier (Opus / Sonnet / Haiku) within and across Claude Code sessions, accounting for prompt-cache invalidation cost.
@@ -10,8 +10,8 @@
 
 Establish a single decision rule for **which model to use** at session start and **whether to switch** mid-session, such that:
 
-1. The default behavior optimizes for **quality**, then cost, then cognitive overhead — in that priority order
-2. Mid-session model switches do not silently waste prompt-cache spend (a round-trip on a warm 50K-token context costs roughly $0.26 — more than the savings on any task under ~10K mechanical tokens, which covers nearly all routine work in this codebase)
+1. The default behavior optimizes for **quality**, then cost, then cognitive overhead - in that priority order
+2. Mid-session model switches do not silently waste prompt-cache spend (a round-trip on a warm 50K-token context costs roughly $0.26 - more than the savings on any task under ~10K mechanical tokens, which covers nearly all routine work in this codebase)
 3. The rule is mechanical enough that the user does not need to make a tier decision every time work begins
 
 ---
@@ -21,10 +21,10 @@ Establish a single decision rule for **which model to use** at session start and
 | # | Question | Decision |
 |---|----------|----------|
 | 1 | Priority order across the three competing concerns | **Quality > Cost > Cognitive overhead** |
-| 2 | Strategy shape | **Option 3 — Hybrid:** session-start tier picked from intent, no mid-session switching |
+| 2 | Strategy shape | **Option 3 - Hybrid:** session-start tier picked from intent, no mid-session switching |
 | 3 | What drives the session-start tier | Session **intent**, derived from a fixed-priority source list (see Architecture) |
 | 4 | Mid-session policy when wrong model is detected | Stay on current model, OR `/clear` + restart, OR save handoff + start a new `claude` session. **Never** mid-session `/model` switch. |
-| 5 | Effort dial (think tokens) | Parallel control, no cache cost — adjust per turn independently of model tier |
+| 5 | Effort dial (think tokens) | Parallel control, no cache cost - adjust per turn independently of model tier |
 
 Rationales for each are in the brainstorm transcript saved to dotfiles#75 (mirrored as the first comment on cc-config#1).
 
@@ -49,11 +49,11 @@ The cache-cost calculus: on a typical 50K-token context, a round-trip through th
 
 If you realize mid-session that you started on the wrong tier, the recovery options are:
 
-1. **Accept it** — finish what you started; the over- or under-spend is bounded by the session length
-2. **`/clear` and restart** — same `claude` process, fresh context, pick the right tier this time
-3. **Save handoff via writing-handoffs and start a new `claude` session** — preserves work-in-progress across the tier switch
+1. **Accept it** - finish what you started; the over- or under-spend is bounded by the session length
+2. **`/clear` and restart** - same `claude` process, fresh context, pick the right tier this time
+3. **Save handoff via writing-handoffs and start a new `claude` session** - preserves work-in-progress across the tier switch
 
-**The one move that is never correct: a mid-session `/model` switch.** It invalidates the warm cache and pays the round-trip cost for whatever savings the cheaper tier might have provided — typically a net loss on the remaining work.
+**The one move that is never correct: a mid-session `/model` switch.** It invalidates the warm cache and pays the round-trip cost for whatever savings the cheaper tier might have provided - typically a net loss on the remaining work.
 
 ### Where session intent comes from
 
@@ -63,9 +63,9 @@ In strict priority order, the first source that yields a value wins:
 2. **The most recent memory entry tagged with intent + recommended model**
 3. **The user's first prompt of the session**
 
-Sources 1 and 2 only work in practice if the previous session reliably produced them. That is the dependency on cc-config#3 (forcing functions) — see Dependencies.
+Sources 1 and 2 only work in practice if the previous session reliably produced them. That is the dependency on cc-config#3 (forcing functions) - see Dependencies.
 
-### Effort dial — parallel, no cache cost
+### Effort dial - parallel, no cache cost
 
 Effort (`xhigh` / `high` / `medium` / `low`) is a per-turn knob that controls thinking budget without invalidating cache. It is therefore decoupled from the tier rule above and is set per turn:
 
@@ -81,25 +81,25 @@ Effort can move freely turn-to-turn within a session. Tier cannot.
 
 ## Dependencies
 
-- **Hard prerequisite:** cc-config#3 — forcing functions, specifically the end-of-session writing-handoffs invocation. Without it, intent source #1 (recent handoff) is empty almost every session, and the rule degrades to "user states intent at session start" (source #3).
-- **Soft prerequisite:** the existing `writing-handoffs` skill must continue to write a `## Recommended Model` section into every handoff doc. (Current skill already does this — no change required, but the policy assumes it.)
+- **Hard prerequisite:** cc-config#3 - forcing functions, specifically the end-of-session writing-handoffs invocation. Without it, intent source #1 (recent handoff) is empty almost every session, and the rule degrades to "user states intent at session start" (source #3).
+- **Soft prerequisite:** the existing `writing-handoffs` skill must continue to write a `## Recommended Model` section into every handoff doc. (Current skill already does this - no change required, but the policy assumes it.)
 
-Until cc-config#3 lands, the rule is still usable — it just leans more heavily on source #3 (user's first prompt) than on the persisted-state sources.
+Until cc-config#3 lands, the rule is still usable - it just leans more heavily on source #3 (user's first prompt) than on the persisted-state sources.
 
 ---
 
 ## Out of scope (explicitly deferred)
 
-- **Statusline display** of current model and inferred session intent — candidate work item for cc-config#3 (forcing functions), not part of this policy spec
-- **Whether to update, delete, or replace the existing `picking-model-tier` skill** — implementation detail for the plan that follows this spec
-- **`/fast` mode** — orthogonal latency optimization on Opus 4.6; does not interact with the tier-selection rule and is not governed by this spec
-- **Auto-detection of session intent from the user's prompt** (NLP classification, etc.) — explicitly rejected during brainstorm in favor of the three-source priority list above; revisit only if source #3 proves unreliable in practice
+- **Statusline display** of current model and inferred session intent - candidate work item for cc-config#3 (forcing functions), not part of this policy spec
+- **Whether to update, delete, or replace the existing `picking-model-tier` skill** - implementation detail for the plan that follows this spec
+- **`/fast` mode** - orthogonal latency optimization on Opus 4.6; does not interact with the tier-selection rule and is not governed by this spec
+- **Auto-detection of session intent from the user's prompt** (NLP classification, etc.) - explicitly rejected during brainstorm in favor of the three-source priority list above; revisit only if source #3 proves unreliable in practice
 
 ---
 
 ## Success criteria
 
-- A fresh `claude` session in any project can answer the question "which tier should I be on?" using only: (a) the most recent handoff doc, (b) the most recent intent-tagged memory entry, or (c) the user's first prompt — in that order — without further user prompting
+- A fresh `claude` session in any project can answer the question "which tier should I be on?" using only: (a) the most recent handoff doc, (b) the most recent intent-tagged memory entry, or (c) the user's first prompt - in that order - without further user prompting
 - Sessions that begin with a handoff doc start on the tier specified by `## Recommended Model` without the user re-stating intent
 - The `picking-model-tier` skill (or whatever replaces it per the implementation plan) refuses to mid-session-switch tier and instead surfaces the three recovery options (accept / `/clear` / handoff + new session)
 - A retroactive review of any session where the wrong tier was used can show that **none** of the recovery actions taken was a mid-session `/model` switch

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -6,10 +6,10 @@ Built for this brain: explicit steps, no hedging, decision tables, named command
 
 ---
 
-## When overwhelmed — minimum viable steps
+## When overwhelmed - minimum viable steps
 
 1. Open this file.
-2. `gh issue list --state open` — what's actually pending.
+2. `gh issue list --state open` - what's actually pending.
 3. Pick **one** issue. Branch: `git checkout -b <topic>`.
 4. Tell Claude in one sentence what you're doing.
 
@@ -32,7 +32,7 @@ Don't try to plan more than one issue at once.
 
 - **One issue at a time.** Resist scope creep.
 - Spotted another bug? → `gh issue create`, then back to current task.
-- Claude shows diffs before applying — by default per memory rules.
+- Claude shows diffs before applying - by default per memory rules.
 - Use `dotfiles-<domain>` skills for domain gotchas: sketchybar, aerospace, nvim, mcp, security, shell.
 - Use `gh issue list --search <topic>` mid-task to confirm what's open.
 
@@ -56,20 +56,20 @@ Don't try to plan more than one issue at once.
 |---------|--------|
 | "I don't know where to start" | `gh issue list` → pick one |
 | "Claude is slow / drifting" | `/clear`, restart with one-sentence goal |
-| "Context feels bloated" | `/compact` — precompact hook injects MEMORY.md + CLAUDE.md |
+| "Context feels bloated" | `/compact` - precompact hook injects MEMORY.md + CLAUDE.md |
 | "Forgot what I was doing" | `git status` + `git log --oneline -5` |
 | "What was decided last time?" | Read `~/.claude/projects/-Users-montrose-dotfiles/memory/MEMORY.md` |
 | "What skill applies here?" | Check the `available skills` list in Claude's session-start reminder |
 
 ---
 
-## Anti-patterns — don't
+## Anti-patterns - don't
 
 - Push directly to `main` (blocked anyway)
 - Edit on `main` without branching first
-- Batch 4+ fixes in one session — one issue, verify, then next
-- Mirror GitHub issues in markdown punchlists — they drift stale
-- Add new long-form content to `CLAUDE.md` — it auto-loads every session; put it in a skill or `docs/`
+- Batch 4+ fixes in one session - one issue, verify, then next
+- Mirror GitHub issues in markdown punchlists - they drift stale
+- Add new long-form content to `CLAUDE.md` - it auto-loads every session; put it in a skill or `docs/`
 
 ---
 
@@ -81,7 +81,7 @@ Don't try to plan more than one issue at once.
 | Repo file inventory | `docs/file-map.md` |
 | Token-aware tool routing (Claude reads) | `~/.claude/plugin-routing.md` |
 | Domain guidance (Claude loads on demand) | `~/.claude/skills/dotfiles-<X>/SKILL.md` |
-| Recent decisions / context | Automem (MCP) — Claude recalls automatically |
+| Recent decisions / context | Automem (MCP) - Claude recalls automatically |
 | Per-project session-recall hints | `~/.claude/projects/-Users-montrose-dotfiles/memory/MEMORY.md` |
 | Plans / specs (write-once, read-once) | `docs/superpowers/{plans,specs}/` |
 
@@ -89,9 +89,9 @@ Don't try to plan more than one issue at once.
 
 ## Token-saving habits
 
-- **Use a skill** instead of explaining context — `/dotfiles-sketchybar` etc.
-- Let `gh issue list` answer "what's open" — don't ask Claude to recall.
-- Don't paste large files into chat — Claude reads files itself.
+- **Use a skill** instead of explaining context - `/dotfiles-sketchybar` etc.
+- Let `gh issue list` answer "what's open" - don't ask Claude to recall.
+- Don't paste large files into chat - Claude reads files itself.
 - Keep `CLAUDE.md` slim. New architecture details → into a skill.
 - `/caveman` = ~75% fewer output tokens; `/caveman:compress <file>` for memory files.
 
@@ -112,6 +112,6 @@ Don't try to plan more than one issue at once.
 
 ## See also
 
-- [`plugin-routing.md`](../plugin-routing.md) — technical routing reference (for Claude)
-- [Spec: model-switching policy](superpowers/specs/2026-04-27-model-switching-policy-design.md) — once written
-- [META issue](https://github.com/jem0ntr053/cc-config/issues) — current workflow improvement work
+- [`plugin-routing.md`](../plugin-routing.md) - technical routing reference (for Claude)
+- [Spec: model-switching policy](superpowers/specs/2026-04-27-model-switching-policy-design.md) - once written
+- [META issue](https://github.com/jem0ntr053/cc-config/issues) - current workflow improvement work

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# cc-config install — symlink contents into ~/.claude/
+# cc-config install - symlink contents into ~/.claude/
 # Idempotent. Re-run after `git pull` to refresh.
 
 set -euo pipefail

--- a/plugin-routing.md
+++ b/plugin-routing.md
@@ -15,12 +15,12 @@ CODE:      brainstorming → writing-plans → executing-plans (TDD inside) → 
 
 ## Always-On Defaults (auto, no invocation)
 
-- caveman mode — terse output (until "stop caveman")
-- automem recall_memory — session start
-- gh issue list — session start (open work tracked in GitHub issues, not markdown)
-- LSP (swift / pyright / lua) — auto on matching file edits
-- picking-model-tier — starting any new task
-- auto-memory writes — learn user fact / feedback / project state / external reference
+- caveman mode - terse output (until "stop caveman")
+- automem recall_memory - session start
+- gh issue list - session start (open work tracked in GitHub issues, not markdown)
+- LSP (swift / pyright / lua) - auto on matching file edits
+- picking-model-tier - starting any new task
+- auto-memory writes - learn user fact / feedback / project state / external reference
 
 ## Skip Rules
 
@@ -102,4 +102,4 @@ caveman:compress         | shrink CLAUDE.md / memory files  | 🟢 | small file
 - context7 for general programming concepts
 - Self-launch ultrareview (user-only)
 - Casually delete `.superpowers/` session dirs
-- Mirror GitHub issues in markdown punchlists or memory snapshots — issues are canonical
+- Mirror GitHub issues in markdown punchlists or memory snapshots - issues are canonical

--- a/skills/picking-model-tier/SKILL.md
+++ b/skills/picking-model-tier/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: picking-model-tier
-description: Use when user asks to start work on an issue/bug/feature, implement something, fix something, or begin any new coding task — checks whether the current model tier (opus/sonnet/haiku) fits the task and tells the user to switch if not.
+description: Use when user asks to start work on an issue/bug/feature, implement something, fix something, or begin any new coding task - checks whether the current model tier (opus/sonnet/haiku) fits the task and tells the user to switch if not.
 ---
 
 # Picking Model Tier
@@ -33,15 +33,15 @@ If current tier matches the task: proceed silently, no need to mention the check
 
 If mismatch, say one short line. Format:
 
-> Task looks [category] ([one-phrase reason]). Suggest `/model <tier>` before we start — [token/capability reason].
+> Task looks [category] ([one-phrase reason]). Suggest `/model <tier>` before we start - [token/capability reason].
 
 Examples:
 
-> Task looks mechanical (rename across 2 files). Suggest `/model haiku` before we start — saves tokens.
+> Task looks mechanical (rename across 2 files). Suggest `/model haiku` before we start - saves tokens.
 
-> Task looks like architecture (no plan yet, cross-file redesign). Suggest `/model opus` before we start — this tier fits design calls.
+> Task looks like architecture (no plan yet, cross-file redesign). Suggest `/model opus` before we start - this tier fits design calls.
 
-> Task looks like plan execution (plans/2026-04-22-x.md already written). Suggest `/model sonnet` before we start — saves opus tokens with no capability loss.
+> Task looks like plan execution (plans/2026-04-22-x.md already written). Suggest `/model sonnet` before we start - saves opus tokens with no capability loss.
 
 ## When NOT to Use
 

--- a/skills/writing-handoffs/SKILL.md
+++ b/skills/writing-handoffs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-handoffs
-description: Use when writing handoff documents — plans/ files, worktree handoff notes, phase transitions, "resume here next session" summaries, or any doc meant for another Claude session to pick up.
+description: Use when writing handoff documents - plans/ files, worktree handoff notes, phase transitions, "resume here next session" summaries, or any doc meant for another Claude session to pick up.
 ---
 
 # Writing Handoffs
@@ -37,12 +37,12 @@ If the doc is NOT a handoff (a spec, a bug report, a README), skip.
 
 ## Required Output Format
 
-Append exactly this block at the end of the handoff (after every other section). The `~~~` below are markdown fences showing the block — paste only the heading and three bullets, not the tildes:
+Append exactly this block at the end of the handoff (after every other section). The `~~~` below are markdown fences showing the block - paste only the heading and three bullets, not the tildes:
 
 ~~~
 ## Recommended Model
 - Model: sonnet
-- Reason: <one sentence, ≤25 words, no em-dash continuation — what the next session is doing and why that tier fits>
+- Reason: <one sentence, ≤25 words, no em-dash continuation - what the next session is doing and why that tier fits>
 - Resume: `/model sonnet`
 ~~~
 


### PR DESCRIPTION
## Summary
- Output of the local em-dash → hyphen linter across all tracked files
- Pure cosmetic; no semantic change
- Bundled separately from the plan PR to keep scopes clean

## Test plan
- [x] secret-scan CI green
- [x] No prose meaning altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)