### PR TITLE
feat: implement model-switching policy (cc-config#1)

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -23,7 +23,7 @@ Don't try to plan more than one issue at once.
 |------|---------|-----|
 | 1. Pick the work | `gh issue list` | Single source of truth |
 | 2. Branch | `git checkout -b <topic>` | Main is protected |
-| 3. Pick model | `/model opus` (design/plan) or `/model sonnet` (mechanical) | `picking-model-tier` skill also nudges |
+| 3. Pick model | Run `/model <tier>` per skill suggestion | `picking-model-tier` reads handoff/memory/first prompt at session start; locks tier for the session |
 | 4. State the goal | One sentence to Claude | "Fix #44 font weight on dark bg" |
 
 ---
@@ -106,12 +106,12 @@ Don't try to plan more than one issue at once.
 | Mechanical edit, follow a plan | Sonnet 4.6 |
 | Trivial chat / quick lookup | Haiku 4.5 |
 
-`picking-model-tier` skill auto-fires at task start to remind.
+`picking-model-tier` fires at session start, consults handoff doc → memory → your first prompt (in that order) and tells you which tier to use. Mid-session it refuses to switch and surfaces three recovery options (accept / `/clear` / handoff + new session).
 
 ---
 
 ## See also
 
 - [`plugin-routing.md`](../plugin-routing.md) - technical routing reference (for Claude)
-- [Spec: model-switching policy](superpowers/specs/2026-04-27-model-switching-policy-design.md) - once written
+- [Spec: model-switching policy](superpowers/specs/2026-04-27-model-switching-policy-design.md)
 - [META issue](https://github.com/jem0ntr053/cc-config/issues) - current workflow improvement work

--- a/plugin-routing.md
+++ b/plugin-routing.md
@@ -36,7 +36,7 @@ ALWAYS-ON
 caveman mode             | terse every reply                | 🟢 | "stop caveman"
 automem recall_memory    | session start                    | 🟢 | offline
 LSP (swift/pyright/lua)  | matching file edits              | 🟢 | non-matching lang
-picking-model-tier       | starting any new task            | 🟢 | trivial chat
+picking-model-tier       | session start (intent-sourced)   | 🟢 | mid-session, chitchat
 auto-memory write        | learn user fact / feedback       | 🟢 | derivable from code
 
 INTAKE / RESEARCH

--- a/skills/picking-model-tier/SKILL.md
+++ b/skills/picking-model-tier/SKILL.md
@@ -7,51 +7,101 @@ description: Use when user asks to start work on an issue/bug/feature, implement
 
 ## Overview
 
-Opus eats tokens. Running mechanical edits on opus is waste. Running architecture calls on haiku is worse. This skill fires at start-of-work to confirm the current model tier matches the task.
+Opus eats tokens. Mechanical edits on opus are waste. Architecture calls on haiku are worse. Worse still: a mid-session `/model` switch invalidates the warm prompt cache and pays a ~$0.26 round-trip on a 50K-token context, exceeding the savings on any task under ~10K mechanical tokens. This skill picks the right tier **once**, at session start, then refuses every subsequent in-session switch.
 
-## The Rule
+The full design is in `docs/superpowers/specs/2026-04-27-model-switching-policy-design.md`.
 
-Before starting work, classify the task per the rubric. If the current model tier doesn't match, tell the user to switch with `/model <tier>` before proceeding. Do not start substantive work until the user confirms or overrides. Classification and brief clarifying questions (e.g. "which three files?") are fine pre-switch; actual edits, commands, and multi-step investigation are gated.
+## When This Skill Fires
 
-## Selection Rubric
+- **Session start (cache cold):** the agent has just been launched, or the user has just run `/clear`. Pick the tier here.
+- **Mid-session (cache warm):** any turn after the first substantive one. Refuse to switch tier; surface the three recovery options instead.
 
-| Task type | Model |
+The two cases use different logic. Do not conflate them.
+
+## Session Start - Pick the Tier
+
+### Step 1: Determine session intent from the priority sources
+
+Consult the three sources below **in strict priority order**. The first source that yields a value wins. Do not consult later sources once a value is found.
+
+**Source #1 - Most recent handoff doc with a `## Recommended Model` section**
+
+Look in the current project's `docs/superpowers/handoffs/` directory (and `plans/` and `docs/superpowers/plans/` as fallbacks - any of those may contain a handoff). Sort by mtime. For the newest file, search for the literal heading `## Recommended Model`. If present, parse the `Model:` line; that tier wins.
+
+```bash
+# Concrete recipe the agent runs:
+ls -t docs/superpowers/handoffs/*.md plans/*.md docs/superpowers/plans/*.md 2>/dev/null \
+  | head -20 \
+  | xargs -I{} sh -c 'grep -l "## Recommended Model" "{}" 2>/dev/null | head -1' \
+  | head -1
+```
+
+If the recipe returns a file, read its `Model:` line and use that tier.
+
+**Source #2 - Most recent `session-handoff-…` memory entry**
+
+Call `mcp__plugin_automem_memory__recall_memory` with a query like `"session-handoff recommended model"` and `limit: 5`. Find the most recent entry whose `name` field starts with `session-handoff-`. Parse the description's `<tier>` placeholder; that tier wins.
+
+If no such memory entry exists, fall through to source #3.
+
+**Source #3 - User's first prompt of the session**
+
+Classify the user's first substantive message against the intent table below. Pick the matching tier.
+
+### Step 2: Map intent to tier
+
+| Session intent | Tier |
 |---|---|
-| Architecture, brainstorming, cross-file design, root-cause debugging of unknown failures | `opus` |
-| Implementing a written plan, test generation from a spec, refactors with clear scope, code review | `sonnet` |
-| Mechanical edits, formatting, renames, single-file tweaks, boilerplate, log parsing | `haiku` |
+| Design / brainstorm / plan / unclear scope | `opus` |
+| Execute a written plan with no judgment calls | `sonnet` |
+| Mechanical edit against a well-specified target | `haiku` |
+| No clear intent | `opus` (quality default) |
 
-## Default Bias (Opus eats tokens)
+### Step 3: Confirm or switch before doing real work
 
-- Task has a written plan → `sonnet`
-- Task is "decide what to do" → `opus`
-- Task is mechanical → `haiku`
+- If the current model already matches the picked tier: proceed silently. Do not announce the check.
+- If the current model is the **wrong** tier: tell the user in one short line, e.g.
 
-## What to Say to the User
+  > Session intent looks like execute-plan (handoff doc names sonnet). Suggest `/model sonnet` before we start - saves opus tokens with no capability loss.
 
-If current tier matches the task: proceed silently, no need to mention the check.
+  Wait for the user to confirm the switch (or override) before starting substantive work. Classification, brief clarifying questions, and reading existing files are fine pre-switch; edits, multi-file investigations, and non-trivial commands are gated.
 
-If mismatch, say one short line. Format:
+## Mid-Session - Refuse to Switch
 
-> Task looks [category] ([one-phrase reason]). Suggest `/model <tier>` before we start - [token/capability reason].
+If at any point during the session the agent would otherwise tell the user to run `/model <tier>`, **stop**. The cache cost of the switch exceeds the savings on essentially every remaining task.
 
-Examples:
+Instead, surface the three recovery options exactly as listed in the spec:
 
-> Task looks mechanical (rename across 2 files). Suggest `/model haiku` before we start - saves tokens.
+> Started on the wrong tier. Three recovery options:
+> 1. **Accept it** - finish what we started; the over- or under-spend is bounded by remaining session length.
+> 2. **`/clear` and restart** - same `claude` process, fresh context (cache resets to cold), pick the right tier this time.
+> 3. **Save handoff via `writing-handoffs` and start a new `claude` session** - preserves work-in-progress across the tier switch.
+>
+> Mid-session `/model` switching is never the right call - it invalidates the warm cache and pays the round-trip cost for whatever savings the cheaper tier might have given.
 
-> Task looks like architecture (no plan yet, cross-file redesign). Suggest `/model opus` before we start - this tier fits design calls.
+Wait for the user to pick one. Do not pre-choose for them. If the user explicitly overrides ("just switch anyway"), honor it but do not initiate it.
 
-> Task looks like plan execution (plans/2026-04-22-x.md already written). Suggest `/model sonnet` before we start - saves opus tokens with no capability loss.
+## Effort Dial - Per-Turn, No Cache Cost
+
+Effort (`xhigh` / `high` / `medium` / `low`) is independent of tier. It controls thinking-token budget without invalidating the prompt cache, so it can be re-set per turn:
+
+| Activity | Effort |
+|---|---|
+| Design / debug / unknown failure mode | `xhigh` or `high` |
+| Standard execution from a written plan | `medium` |
+| Mechanical edit | `low` |
+
+Adjust effort freely. Adjust tier never (within a session).
 
 ## When NOT to Use
 
-- User already on the matching tier → proceed silently.
-- Continuation of existing in-session work → don't re-check mid-task.
-- User explicitly says "stay on <model>" or "don't switch" → honor override.
-- One-off questions / quick lookups → not "starting work."
+- Continuation of in-session work past the first substantive turn - the session-start check has already happened; do not re-run it.
+- One-off questions, lookups, or chitchat - not a "session" in the cache-amortization sense.
+- User explicitly says "stay on `<model>`" or "don't check tier" - honor the override.
 
 ## Red Flags
 
-- User says "let's work on #N", "fix this bug", "implement X", "start on Y" → this skill applies; run the check.
-- About to dive into edits without classifying task → stop and classify first.
-- Tier mismatch + proceeding anyway → wrong.
+- About to suggest a mid-session `/model` switch → wrong; surface the three recovery options instead.
+- About to dive into substantive edits without consulting the priority-source list → stop and consult.
+- Found a handoff doc but ignored it in favor of classifying the user's prompt → wrong; source #1 wins.
+- Adjusting effort confused with adjusting tier → effort is per-turn-fine, tier is per-session-locked.

--- a/skills/writing-handoffs/SKILL.md
+++ b/skills/writing-handoffs/SKILL.md
@@ -48,6 +48,21 @@ Append exactly this block at the end of the handoff (after every other section).
 
 Fill `Model` and `Resume` with the actual choice. `Reason` must be ONE sentence (one period, ≤25 words, no em-dash splicing), concrete about the next step (not "the work continues").
 
+## Required Memory Write
+
+After writing the handoff doc, also store a memory entry so the next session can recover the recommended model even if the handoff file is deleted or the next session is cross-project.
+
+Call `mcp__plugin_automem_memory__store_memory` with exactly this shape:
+
+- **name:** `session-handoff-YYYY-MM-DD-HHMM` (use the timestamp at handoff write time, in UTC)
+- **description:** `Session handoff: next session should use <tier>. Intent: <intent-category>.`
+  - `<tier>` is one of `opus`, `sonnet`, `haiku` - must match the `Model:` line in the doc
+  - `<intent-category>` is one of `design`, `execute-plan`, `mechanical`, `unclear`
+- **type:** `project`
+- **content:** the full Recommended Model block (three lines: `Model: ...`, `Reason: ...`, `Resume: ...`) verbatim, so the source-of-truth tier is captured in the body
+
+This memory write is **mandatory**, not optional. The picking-model-tier skill consults it as intent source #2.
+
 ## Examples
 
 **Good:**


### PR DESCRIPTION
## Summary
Implements the approved model-switching policy from `docs/superpowers/specs/2026-04-27-model-switching-policy-design.md`, executing the merged plan at `docs/superpowers/plans/2026-04-27-model-switching-policy.md`.

Four commits, four scoped changes:
1. **`feat(writing-handoffs)`** - new `## Required Memory Write` section directs the skill to also store a `session-handoff-…` memory entry alongside the doc, populating intent source #2.
2. **`feat(picking-model-tier)`** - full body rewrite: three priority intent sources, four-row intent→tier rule, mid-session refusal with three recovery options, effort dial as per-turn parallel control. Frontmatter unchanged.
3. **`docs(plugin-routing)`** - one-row description update reflecting intent-sourced behavior.
4. **`docs(workflow)`** - three small prose touch-ups in the human-readable companion (table row, quick-rule paragraph, stale "once written" caveat removed).

## Closes / Refs
- Refs cc-config#1
- Hard prereq cc-config#3 (forcing functions) noted as not blocking; until #3 lands, source #3 (your first prompt) carries the policy.

## Test plan (manual, from a fresh `claude` session - per plan Task 5)
- [ ] Scenario 1: design intent → opus
- [ ] Scenario 2: execute-plan intent → sonnet
- [ ] Scenario 3: mechanical intent → haiku
- [ ] Scenario 4: unclear intent → opus (quality default)
- [ ] Scenario 5: source #1 wins (handoff doc beats prompt classification)
- [ ] Scenario 6: source #2 wins when handoff absent but memory entry present
- [ ] Scenario 7: mid-session refusal surfaces three recovery options verbatim
- [ ] Scenario 8: writing-handoffs writes both source #1 (file) and source #2 (memory)
- [x] secret-scan CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)