### PR TITLE
fix: picking-model-tier SessionStart hook + frontmatter tightening

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ bash install.sh
 
 Idempotent. Re-run after `git pull` to refresh symlinks.
 
+### Wire the SessionStart hook
+
+`install.sh` symlinks `hooks/picking-model-tier-context.sh` into `~/.claude/hooks/`, but the harness only runs it if it's registered as a `SessionStart` hook in `~/.claude/settings.json`. Add this once per machine (use the `update-config` skill in any Claude Code session, or edit settings directly):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$HOME/.claude/hooks/picking-model-tier-context.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Without this wiring, `picking-model-tier` falls back to description-based discovery and may lose priority to `brainstorming` / `systematic-debugging` on prompts that match those skills strongly. The hook is the durable forcing function.
+
 ## Dev setup (contributors only)
 
 After cloning, wire the local pre-commit hook so secrets get caught before they ever reach a commit:
@@ -29,9 +49,10 @@ The same scan runs in CI (`.github/workflows/secret-scan.yml`) and is a required
 | Path | What lives here |
 |------|-----------------|
 | `plugin-routing.md` | Canonical token-aware tool/skill routing reference. Auto-loaded by the global CLAUDE.md via `@~/.claude/plugin-routing.md`. |
-| `skills/picking-model-tier/` | Skill - checks task vs current model tier at start-of-work. |
-| `skills/writing-handoffs/` | Skill - appends `## Recommended Model` section to handoff docs. |
+| `skills/picking-model-tier/` | Skill - session-start tier picker. Reads intent sources (handoff doc / memory / first prompt), picks tier, refuses mid-session switching. |
+| `skills/writing-handoffs/` | Skill - appends `## Recommended Model` section to handoff docs and stores a `session-handoff-…` memory entry. |
 | `hooks/precompact-context.sh` | PreCompact hook - injects MEMORY.md + CLAUDE.md into compaction context. |
+| `hooks/picking-model-tier-context.sh` | SessionStart hook - forces `picking-model-tier` to fire as the first skill of every session, ahead of brainstorming / debugging / etc. |
 | `docs/workflow.md` | Human-readable one-page playbook (companion to `plugin-routing.md` which is for Claude). |
 | `docs/superpowers/specs/` | Design docs for workflow improvements (model-switching policy, forcing functions, etc.). |
 | `docs/superpowers/plans/` | Implementation plans derived from specs. |

--- a/hooks/picking-model-tier-context.sh
+++ b/hooks/picking-model-tier-context.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SessionStart hook: force picking-model-tier skill to fire as the very first
+# action of every session, ahead of brainstorming / debugging / any other skill.
+#
+# Why a hook: skill discovery is description-based and probabilistic. Other
+# "MUST use" skills (brainstorming, debugging) outrank picking-model-tier on
+# strong-prompt matches and skip the tier check entirely. This hook injects
+# a system-reminder that overrides discovery and pins picking-model-tier as
+# the first skill of the session.
+
+set -euo pipefail
+
+context=$(cat <<'CTX'
+SESSION START - picking-model-tier pre-flight check required.
+
+After receiving the user's first substantive prompt, BEFORE any other action
+(including invoking other skills like brainstorming, systematic-debugging,
+writing-plans, etc., and including ALL tool calls except this one), invoke
+the picking-model-tier skill via the Skill tool:
+
+  Skill({ skill: "picking-model-tier" })
+
+This is the FIRST thing you do every session. Non-negotiable. The skill
+will read intent sources (handoff doc / memory / first prompt), pick a tier,
+and either proceed silently (if current model matches) or tell the user to
+/model switch before substantive work.
+
+If picking-model-tier has already fired in this session (after a /clear or
+on a resumed session that already passed the pre-flight), skip.
+CTX
+)
+
+jq -n --arg ctx "$context" \
+  '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$ctx}}'

--- a/install.sh
+++ b/install.sh
@@ -9,15 +9,16 @@ TARGET="$HOME/.claude"
 
 mkdir -p "$TARGET/skills" "$TARGET/hooks"
 
-ln -sfn "$SOURCE/plugin-routing.md"           "$TARGET/plugin-routing.md"
-ln -sfn "$SOURCE/skills/picking-model-tier"   "$TARGET/skills/picking-model-tier"
-ln -sfn "$SOURCE/skills/writing-handoffs"     "$TARGET/skills/writing-handoffs"
-ln -sfn "$SOURCE/hooks/precompact-context.sh" "$TARGET/hooks/precompact-context.sh"
+ln -sfn "$SOURCE/plugin-routing.md"                   "$TARGET/plugin-routing.md"
+ln -sfn "$SOURCE/skills/picking-model-tier"           "$TARGET/skills/picking-model-tier"
+ln -sfn "$SOURCE/skills/writing-handoffs"             "$TARGET/skills/writing-handoffs"
+ln -sfn "$SOURCE/hooks/precompact-context.sh"         "$TARGET/hooks/precompact-context.sh"
+ln -sfn "$SOURCE/hooks/picking-model-tier-context.sh" "$TARGET/hooks/picking-model-tier-context.sh"
 
 echo "cc-config installed → $TARGET"
 echo
 echo "Symlinks:"
-for link in plugin-routing.md skills/picking-model-tier skills/writing-handoffs hooks/precompact-context.sh; do
+for link in plugin-routing.md skills/picking-model-tier skills/writing-handoffs hooks/precompact-context.sh hooks/picking-model-tier-context.sh; do
   printf "  %-40s -> " "$TARGET/$link"
   readlink "$TARGET/$link" || echo "(missing)"
 done

--- a/skills/picking-model-tier/SKILL.md
+++ b/skills/picking-model-tier/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: picking-model-tier
-description: Use when user asks to start work on an issue/bug/feature, implement something, fix something, or begin any new coding task - checks whether the current model tier (opus/sonnet/haiku) fits the task and tells the user to switch if not.
+description: FIRST SKILL TO FIRE EVERY SESSION. Pre-flight tier check that runs BEFORE brainstorming, systematic-debugging, writing-plans, or any other skill. Reads intent sources (handoff doc / memory / first prompt), picks tier (opus/sonnet/haiku), tells the user to /model switch if mismatched. Fires on EVERY first substantive prompt - design, fix, implement, plan, brainstorm, mechanical, or anything else. Mid-session: refuses to switch tiers and surfaces three recovery options instead.
 ---
 
 # Picking Model Tier


### PR DESCRIPTION
## Summary
Closes #11. Two-part fix for the picking-model-tier discovery failure surfaced by Scenario 1 of cc-config#1's Plan Task 5.

**Fix A - frontmatter description tightening** (`skills/picking-model-tier/SKILL.md`)
- Leads with "FIRST SKILL TO FIRE EVERY SESSION"
- Names the competitor skills it must outrank (brainstorming / systematic-debugging / writing-plans)
- Drops the narrow "implement / fix" verb list that was missing "design"-class prompts

**Fix B - SessionStart hook** (`hooks/picking-model-tier-context.sh`)
- New hook script mirroring the automem recall_memory pattern
- Outputs `hookSpecificOutput.additionalContext` JSON with a SESSION START reminder forcing the agent to invoke picking-model-tier as the FIRST action of every session
- `install.sh` symlinks it into `~/.claude/hooks/`
- README documents the one-time `~/.claude/settings.json` SessionStart wiring (use `update-config` skill or edit directly)

## Closes / Refs
- Closes #11
- Refs #1 (parent issue)

## Test plan
- [x] Hook script smoke-test: `bash hooks/picking-model-tier-context.sh | jq .` produces well-formed JSON
- [x] secret-scan CI green
- [x] After merge + `bash install.sh` + settings.json wiring: re-run cc-config#1 Scenario 1 (fresh `claude` on haiku, prompt "Help me design a feature flag system from scratch") - expect picking-model-tier to fire and suggest `/model opus`
- [x] Re-run Scenario 7 (mid-session refusal) - expect three recovery options surfaced verbatim (no regression)