### PR TITLE
fix: SessionStart hook output format

### DIFF
--- a/hooks/picking-model-tier-context.sh
+++ b/hooks/picking-model-tier-context.sh
@@ -31,4 +31,4 @@ CTX
 )
 
 jq -n --arg ctx "$context" \
-  '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$ctx}}'
+  '{additionalContext:$ctx}'


### PR DESCRIPTION
Simplify hook JSON to match other hooks (additionalContext only, no wrapper). May resolve picking-model-tier not firing at session start.