### PR TITLE
fix: restore hookSpecificOutput wrapper in hook

### DIFF
--- a/hooks/picking-model-tier-context.sh
+++ b/hooks/picking-model-tier-context.sh
@@ -31,4 +31,4 @@ CTX
 )
 
 jq -n --arg ctx "$context" \
-  '{additionalContext:$ctx}'
+  '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$ctx}}'


### PR DESCRIPTION
Reverts PR #13. Wrapper is required - precompact-context.sh uses same pattern.