### PR TITLE
docs(plugin-routing): add column headers and audience clarification

### DIFF
--- a/plugin-routing.md
+++ b/plugin-routing.md
@@ -2,6 +2,8 @@
 
 Canonical token-aware routing. Pick the right tool for the phase. Cheap calls first, heavy workflows only when warranted.
 
+**Audience:** Claude (auto-loaded). Human-readable companion: `docs/workflow.md`.
+
 Legend: 🟢 cheap/free · 🟡 medium · 🔴 heavy
 
 ## Phase Strips (lifecycle order)
@@ -32,6 +34,8 @@ CODE:      brainstorming → writing-plans → executing-plans (TDD inside) → 
 ## Trigger Table
 
 ```
+Skill | When to use | Cost | When to skip
+
 ALWAYS-ON
 caveman mode             | terse every reply                | 🟢 | "stop caveman"
 automem recall_memory    | session start                    | 🟢 | offline


### PR DESCRIPTION
Add header row to trigger table for clarity: Skill | When to use | Cost | When to skip

Add audience header clarifying file is auto-loaded for Claude, with reference to docs/workflow.md as the human-readable companion.

Closes #4