### PR TITLE
chore: track .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+    "editor.fontSize": 16,
+    "cSpell.words": [
+        "agentic",
+        "chezmoi",
+        "esac",
+        "frontmatter",
+        "gpgsign",
+        "montrose",
+        "oneline",
+        "prereq",
+        "punchlists",
+        "readlink",
+        "startswith",
+        "ultrareview",
+        "Wakeup",
+        "worktree",
+        "worktrees",
+        "xhigh"
+    ]
+}


### PR DESCRIPTION
## Summary
- Track `.vscode/settings.json` with repo-specific cspell dictionary (ultrareview, chezmoi, worktree, frontmatter, etc.) and editor font size
- Personal `cc-config` repo — sharing editor config keeps spell-check clean across machines

## Test plan
- [x] File contents reviewed (cspell words + fontSize only, no secrets)
- [x] No `.vscode/` entry in `.gitignore` to conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)