### PR TITLE
chore(hooks): block direct commits on main

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Block commits that introduce secrets. Mirrors the CI gitleaks job locally.
+# Also block commits directly to main so PR workflow stays clean.
 set -euo pipefail
+
+branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+if [ "$branch" = "main" ]; then
+  echo "pre-commit: refusing to commit on main." >&2
+  echo "  create a branch first:  git checkout -b <type>/<short-name>" >&2
+  echo "  bypass (rare):          git commit --no-verify" >&2
+  exit 1
+fi
 
 if ! command -v gitleaks >/dev/null 2>&1; then
   echo "pre-commit: gitleaks not installed - skipping secret scan" >&2


### PR DESCRIPTION
## Summary
- Add main-branch guard to `.githooks/pre-commit` — refuses commits on `main`, prints the create-branch hint, allows `--no-verify` bypass
- Gitleaks secret scan retained
- (Out-of-diff, repo-local) `git config pull.rebase=true` set so squash-merge divergence auto-resolves on next pull

## Why
Squash-merging own PRs creates a local-vs-origin divergence pattern (local commit + remote `(#N)` dup with identical tree). Branch-first prevents the dirty local-main; rebase-on-pull handles any leftover divergence cleanly.

## Test plan
- [x] Hook runs locally (this commit was made on `chore/main-branch-guard`, hook allowed it)
- [ ] Try `git commit` directly on main after merge — should be refused with hint
- [ ] Gitleaks still runs on staged files

🤖 Generated with [Claude Code](https://claude.com/claude-code)